### PR TITLE
Converted Selenium-based C# automation framework to Playwright-based C# framework

### DIFF
--- a/Playwright/Actions/LoginActions.cs
+++ b/Playwright/Actions/LoginActions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using SwagLabProject.Playwright.Pages;
+
+namespace SwagLabProject.Playwright.Actions
+{
+    public class LoginActions
+    {
+        private readonly LoginPage _loginPage;
+
+        public LoginActions(IPage page) => _loginPage = new LoginPage(page);
+
+        public async Task LoginAsync(string username, string password)
+        {
+            await _loginPage.EnterUsernameAsync(username);
+            await _loginPage.EnterPasswordAsync(password);
+            await _loginPage.ClickLoginAsync();
+        }
+    }
+}

--- a/Playwright/Drivers/WebDriverSetup.cs
+++ b/Playwright/Drivers/WebDriverSetup.cs
@@ -1,0 +1,30 @@
+using Microsoft.Playwright;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace SwagLabProject.Playwright.Drivers
+{
+    public class WebDriverSetup
+    {
+        protected IPlaywright playwright;
+        protected IBrowser browser;
+        protected IPage page;
+
+        [SetUp]
+        public async Task SetupAsync()
+        {
+            playwright = await Playwright.CreateAsync();
+            browser = await playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+            var context = await browser.NewContextAsync();
+            page = await context.NewPageAsync();
+            await page.GotoAsync("https://www.saucedemo.com/");
+        }
+
+        [TearDown]
+        public async Task TearDownAsync()
+        {
+            await browser.CloseAsync();
+            playwright.Dispose();
+        }
+    }
+}

--- a/Playwright/Pages/LoginPage.cs
+++ b/Playwright/Pages/LoginPage.cs
@@ -1,0 +1,21 @@
+using Microsoft.Playwright;
+using System.Threading.Tasks;
+
+namespace SwagLabProject.Playwright.Pages
+{
+    public class LoginPage
+    {
+        private readonly IPage _page;
+        private readonly string _usernameField = "#user-name";
+        private readonly string _passwordField = "#password";
+        private readonly string _loginButton = "#login-button";
+
+        public LoginPage(IPage page) => _page = page;
+
+        public async Task EnterUsernameAsync(string username) => await _page.FillAsync(_usernameField, username);
+        public async Task EnterPasswordAsync(string password) => await _page.FillAsync(_passwordField, password);
+        public async Task ClickLoginAsync() => await _page.ClickAsync(_loginButton);
+
+        public async Task<bool> IsOnLoginPageAsync() => (await _page.UrlAsync()).Contains("saucedemo");
+    }
+}

--- a/Playwright/TestSuite/LoginTests.cs
+++ b/Playwright/TestSuite/LoginTests.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+using SwagLabProject.Playwright.Actions;
+using SwagLabProject.Playwright.Drivers;
+using System.Threading.Tasks;
+
+namespace SwagLabProject.Playwright.TestSuite
+{
+    public class LoginTests : WebDriverSetup
+    {
+        [Test]
+        public async Task Login_WithValidCredentials_ShouldBeSuccessful()
+        {
+            var loginActions = new LoginActions(page);
+            await loginActions.LoginAsync("standard_user", "secret_sauce");
+
+            var loginPage = new SwagLabProject.Playwright.Pages.LoginPage(page);
+            Assert.That((await page.UrlAsync()).Contains("inventory"), "Login failed!");
+        }
+    }
+}


### PR DESCRIPTION
The following changes have been made to convert the Selenium-based C# automation framework to a Playwright-based C# framework:

- Created `Playwright/Actions/LoginActions.cs` to replace Selenium actions with Playwright actions.
- Created `Playwright/Drivers/WebDriverSetup.cs` to set up and tear down Playwright browser instances.
- Created `Playwright/Pages/LoginPage.cs` to interact with the login page using Playwright.
- Created `Playwright/TestSuite/LoginTests.cs` to run login tests using Playwright.

All test cases have been converted to use Playwright's asynchronous methods and modern browser automation capabilities while maintaining the original structure and functionality.

closes #1