### PR TITLE
Convert Selenium-based framework to Playwright .NET

### DIFF
--- a/PlaywrightCode/Actions/LoginActions.cs
+++ b/PlaywrightCode/Actions/LoginActions.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using SwagLabProject.PlaywrightCode.Pages;
+
+namespace SwagLabProject.PlaywrightCode.Actions
+{
+    public class LoginActions
+    {
+        private readonly LoginPage _loginPage;
+
+        public LoginActions(IPage page)
+        {
+            _loginPage = new LoginPage(page);
+        }
+
+        public async Task LoginAsync(string username, string password)
+        {
+            await _loginPage.EnterUsernameAsync(username);
+            await _loginPage.EnterPasswordAsync(password);
+            await _loginPage.ClickLoginAsync();
+        }
+    }
+}

--- a/PlaywrightCode/Drivers/WebDriverSetup.cs
+++ b/PlaywrightCode/Drivers/WebDriverSetup.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace SwagLabProject.PlaywrightCode.Drivers
+{
+    public class WebDriverSetup
+    {
+        protected IPlaywright Playwright;
+        protected IBrowser Browser;
+        protected IBrowserContext Context;
+        protected IPage Page;
+
+        [SetUp]
+        public async Task SetupAsync()
+        {
+            Playwright = await Microsoft.Playwright.Playwright.CreateAsync();
+            Browser = await Playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = true });
+            Context = await Browser.NewContextAsync();
+            Page = await Context.NewPageAsync();
+            await Page.GotoAsync("https://www.saucedemo.com/");
+        }
+
+        [TearDown]
+        public async Task TearDownAsync()
+        {
+            await Browser.CloseAsync();
+            Playwright.Dispose();
+        }
+    }
+}

--- a/PlaywrightCode/Pages/LoginPage.cs
+++ b/PlaywrightCode/Pages/LoginPage.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace SwagLabProject.PlaywrightCode.Pages
+{
+    public class LoginPage
+    {
+        private readonly IPage _page;
+        private readonly ILocator _usernameField;
+        private readonly ILocator _passwordField;
+        private readonly ILocator _loginButton;
+
+        public LoginPage(IPage page)
+        {
+            _page = page;
+            _usernameField = _page.Locator("#user-name");
+            _passwordField = _page.Locator("#password");
+            _loginButton = _page.Locator("#login-button");
+        }
+
+        public async Task EnterUsernameAsync(string username)
+        {
+            await _usernameField.FillAsync(username);
+        }
+
+        public async Task EnterPasswordAsync(string password)
+        {
+            await _passwordField.FillAsync(password);
+        }
+
+        public async Task ClickLoginAsync()
+        {
+            await _loginButton.ClickAsync();
+        }
+
+        public async Task<bool> IsOnLoginPageAsync()
+        {
+            return (await _page.UrlAsync()).Contains("saucedemo");
+        }
+    }
+}

--- a/PlaywrightCode/TestSuite/LoginTests.cs
+++ b/PlaywrightCode/TestSuite/LoginTests.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SwagLabProject.PlaywrightCode.Actions;
+using SwagLabProject.PlaywrightCode.Drivers;
+
+namespace SwagLabProject.PlaywrightCode.TestSuite
+{
+    public class LoginTests : WebDriverSetup
+    {
+        [Test]
+        public async Task Login_WithValidCredentials_ShouldBeSuccessful()
+        {
+            var loginActions = new LoginActions(Page);
+            await loginActions.LoginAsync("standard_user", "secret_sauce");
+
+            var loginPage = new SwagLabProject.PlaywrightCode.Pages.LoginPage(Page);
+            Assert.That((await Page.UrlAsync()).Contains("inventory"), "Login failed!");
+        }
+    }
+}


### PR DESCRIPTION
Converted the Selenium-based automation framework to Playwright .NET while adhering to best practices and strict coding standards. The following changes were made:

1. **Actions**:
   - Created `LoginActions.cs` to handle login-related actions using Playwright.

2. **Drivers**:
   - Created `WebDriverSetup.cs` to manage Playwright browser setup and teardown.

3. **Pages**:
   - Created `LoginPage.cs` to encapsulate login page interactions using Playwright locators.

4. **TestSuite**:
   - Created `LoginTests.cs` to validate login functionality using NUnit and Playwright.

Namespaces included:
- `Microsoft.Playwright`
- `System.Threading.Tasks`
- `NUnit.Framework`

Target framework: `net48`.

closes #<issue_number_if_any>