### PR TITLE
Convert Selenium to Playwright .NET

### DIFF
--- a/PlaywrightCode/Actions/LoginActions.cs
+++ b/PlaywrightCode/Actions/LoginActions.cs
@@ -1,0 +1,1 @@
+using System.Threading.Tasks;\nusing Microsoft.Playwright;\nusing SwagLabProject.PlaywrightCode.Pages;\n\nnamespace SwagLabProject.PlaywrightCode.Actions\n{\n    public class LoginActions\n    {\n        private readonly LoginPage _loginPage;\n\n        public LoginActions(IPage page) => _loginPage = new LoginPage(page);\n

--- a/PlaywrightCode/Drivers/WebDriverSetup.cs
+++ b/PlaywrightCode/Drivers/WebDriverSetup.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace SwagLabProject.PlaywrightCode.Drivers
+{
+    public class WebDriverSetup
+    {
+        protected IPage Page;
+        private IBrowser _browser;
+        private IPlaywright _playwright;
+
+        [SetUp]
+        public async Task SetupAsync()
+        {
+            _playwright = await Playwright.CreateAsync();
+            _browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+            var context = await _browser.NewContextAsync();
+            Page = await context.NewPageAsync();
+            await Page.GotoAsync("https://www.saucedemo.com/");
+        }
+
+        [TearDown]
+        public async Task TearDownAsync()
+        {
+            await _browser.CloseAsync();
+            _playwright.Dispose();
+        }
+    }
+}

--- a/PlaywrightCode/Pages/LoginPage.cs
+++ b/PlaywrightCode/Pages/LoginPage.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+
+namespace SwagLabProject.PlaywrightCode.Pages
+{
+    public class LoginPage
+    {
+        private readonly IPage _page;
+        private readonly string _usernameSelector = "#user-name";
+        private readonly string _passwordSelector = "#password";
+        private readonly string _loginButtonSelector = "#login-button";
+
+        public LoginPage(IPage page) => _page = page;
+
+        public async Task EnterUsernameAsync(string username) => await _page.FillAsync(_usernameSelector, username);
+        public async Task EnterPasswordAsync(string password) => await _page.FillAsync(_passwordSelector, password);
+        public async Task ClickLoginAsync() => await _page.ClickAsync(_loginButtonSelector);
+
+        public async Task<bool> IsOnLoginPageAsync() => (await _page.Url).Contains("saucedemo");
+    }
+}

--- a/PlaywrightCode/TestSuite/LoginTests.cs
+++ b/PlaywrightCode/TestSuite/LoginTests.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+using Microsoft.Playwright;
+using NUnit.Framework;
+using SwagLabProject.PlaywrightCode.Actions;
+using SwagLabProject.PlaywrightCode.Drivers;
+
+namespace SwagLabProject.PlaywrightCode.TestSuite
+{
+    public class LoginTests : WebDriverSetup
+    {
+        [Test]
+        public async Task Login_WithValidCredentials_ShouldBeSuccessful()
+        {
+            var loginActions = new LoginActions(Page);
+            await loginActions.LoginAsync("standard_user", "secret_sauce");
+
+            var loginPage = new SwagLabProject.PlaywrightCode.Pages.LoginPage(Page);
+            Assert.That((await Page.Url).Contains("inventory"), "Login failed!");
+        }
+    }
+}


### PR DESCRIPTION
Converted the Selenium-based C# automation framework to Playwright .NET-based C# framework. The conversion includes:

- Replaced IWebDriver with IPage for browser automation.
- Used Playwright's asynchronous methods for navigation and interaction.
- Ensured proper browser context management.
- Maintained NUnit testing framework compatibility.

The outdated Page.UrlAsync() method was replaced with Page.Url as per the Playwright Page Class Documentation.

closes #3