### PR TITLE
Convert Selenium to Playwright .NET

### DIFF
--- a/PlaywrightCode/Actions/LoginActions.cs
+++ b/PlaywrightCode/Actions/LoginActions.cs
@@ -1,0 +1,1 @@
+using Microsoft.Playwright;\nusing System.Threading.Tasks;\nusing SwagLabProject.PlaywrightCode.Pages;\n\nnamespace Swag

--- a/PlaywrightCode/Drivers/WebDriverSetup.cs
+++ b/PlaywrightCode/Drivers/WebDriverSetup.cs
@@ -1,0 +1,30 @@
+using Microsoft.Playwright;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+namespace SwagLabProject.PlaywrightCode.Drivers
+{
+    public class WebDriverSetup
+    {
+        protected IPage Page;
+        private IBrowser _browser;
+        private IPlaywright _playwright;
+
+        [SetUp]
+        public async Task SetupAsync()
+        {
+            _playwright = await Playwright.CreateAsync();
+            _browser = await _playwright.Chromium.LaunchAsync(new BrowserTypeLaunchOptions { Headless = false });
+            var context = await _browser.NewContextAsync();
+            Page = await context.NewPageAsync();
+            await Page.GotoAsync("https://www.saucedemo.com/");
+        }
+
+        [TearDown]
+        public async Task TearDownAsync()
+        {
+            await _browser.CloseAsync();
+            _playwright.Dispose();
+        }
+    }
+}

--- a/PlaywrightCode/Pages/LoginPage.cs
+++ b/PlaywrightCode/Pages/LoginPage.cs
@@ -1,0 +1,18 @@
+using Microsoft.Playwright;
+using System.Threading.Tasks;
+
+namespace SwagLabProject.PlaywrightCode.Pages
+{
+    public class LoginPage
+    {
+        private readonly IPage _page;
+
+        public LoginPage(IPage page) => _page = page;
+
+        public async Task EnterUsernameAsync(string username) => await _page.Locator("#user-name").FillAsync(username);
+        public async Task EnterPasswordAsync(string password) => await _page.Locator("#password").FillAsync(password);
+        public async Task ClickLoginAsync() => await _page.Locator("#login-button").ClickAsync();
+
+        public async Task<bool> IsOnLoginPageAsync() => (await _page.Url).Contains("saucedemo");
+    }
+}

--- a/PlaywrightCode/TestSuite/LoginTests.cs
+++ b/PlaywrightCode/TestSuite/LoginTests.cs
@@ -1,0 +1,20 @@
+using NUnit.Framework;
+using SwagLabProject.PlaywrightCode.Actions;
+using SwagLabProject.PlaywrightCode.Drivers;
+using System.Threading.Tasks;
+
+namespace SwagLabProject.PlaywrightCode.TestSuite
+{
+    public class LoginTests : WebDriverSetup
+    {
+        [Test]
+        public async Task Login_WithValidCredentials_ShouldBeSuccessfulAsync()
+        {
+            var loginActions = new LoginActions(Page);
+            await loginActions.LoginAsync("standard_user", "secret_sauce");
+
+            var loginPage = new SwagLabProject.PlaywrightCode.Pages.LoginPage(Page);
+            Assert.That((await Page.Url).Contains("inventory"), "Login failed!");
+        }
+    }
+}


### PR DESCRIPTION
Converted the existing Selenium-based C# automation framework to Playwright .NET. This includes:

- Replacing `IWebDriver` with `IPage` for browser automation.
- Utilizing Playwright's asynchronous methods and locators.
- Removing explicit waits and leveraging Playwright's auto-waiting.
- Ensuring proper browser context management and teardown.
- Maintaining NUnit testing framework compatibility.

closes #1